### PR TITLE
squid:S1125 - Literal boolean values should not be used in condition …

### DIFF
--- a/app/src/main/java/com/tzutalin/vision/demo/ObjectDetectActivity.java
+++ b/app/src/main/java/com/tzutalin/vision/demo/ObjectDetectActivity.java
@@ -54,7 +54,7 @@ public class ObjectDetectActivity extends Activity {
         mListView = (MaterialListView) findViewById(R.id.material_listview);
         final String key = Camera2BasicFragment.KEY_IMGPATH;
         String imgPath = getIntent().getExtras().getString(key);
-        if (new File(imgPath).exists() == false) {
+        if (!new File(imgPath).exists()) {
             Toast.makeText(this, "No file path", Toast.LENGTH_SHORT).show();
             this.finish();
             return;

--- a/app/src/main/java/com/tzutalin/vision/demo/SceneRecognitionActivity.java
+++ b/app/src/main/java/com/tzutalin/vision/demo/SceneRecognitionActivity.java
@@ -56,7 +56,7 @@ public class SceneRecognitionActivity extends Activity {
         mListView = (MaterialListView) findViewById(R.id.material_listview);
         final String key = Camera2BasicFragment.KEY_IMGPATH;
         String imgPath = getIntent().getExtras().getString(key);
-        if (new File(imgPath).exists() == false) {
+        if (!new File(imgPath).exists()) {
             Toast.makeText(this, "No file path", Toast.LENGTH_SHORT).show();
             this.finish();
             return;

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/ObjectDetector.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/ObjectDetector.java
@@ -46,9 +46,9 @@ public class ObjectDetector extends CaffeClassifier <List<VisionDetRet>>{
      */
     public ObjectDetector(Context context, String modelPath, String wieghtsPath, String manefile, String synsetFile) throws IllegalAccessException {
         super(context, modelPath, wieghtsPath, manefile, synsetFile);
-        if (new File(mModelPath).exists() == false ||
-                new File(mWeightsPath).exists() == false ||
-                new File(mSynsetPath).exists() == false ) {
+        if (!new File(mModelPath).exists() ||
+                !new File(mWeightsPath).exists() ||
+                !new File(mSynsetPath).exists() ) {
             throw new IllegalAccessException("ObjectDetector cannot find model");
         }
     }
@@ -89,7 +89,7 @@ public class ObjectDetector extends CaffeClassifier <List<VisionDetRet>>{
     public List<VisionDetRet> classifyByPath(String imgPath) {
         List<VisionDetRet> ret = new ArrayList<VisionDetRet>();
 
-        if (TextUtils.isEmpty(imgPath) || new File(imgPath).exists() == false) {
+        if (TextUtils.isEmpty(imgPath) || !new File(imgPath).exists()) {
             Log.e(TAG, "classifyByPath. Invalid Input path");
             return ret;
         }

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/SceneClassifier.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/SceneClassifier.java
@@ -50,9 +50,9 @@ public class SceneClassifier extends CaffeClassifier<List<VisionDetRet>> {
      */
     public SceneClassifier(Context context, String sceneModelPath, String sceneWieghtsPath, String sceneManefile, String sceneSynsetFile) throws IllegalAccessException {
         super(context, sceneModelPath, sceneWieghtsPath, sceneManefile, sceneSynsetFile);
-        if (new File(mModelPath).exists() == false ||
-                new File(mWeightsPath).exists() == false ||
-                new File(mSynsetPath).exists() == false ) {
+        if (!new File(mModelPath).exists() ||
+                !new File(mWeightsPath).exists() ||
+                !new File(mSynsetPath).exists() ) {
             throw new IllegalAccessException("SceneClassifier cannot find model");
         }
     }
@@ -70,7 +70,7 @@ public class SceneClassifier extends CaffeClassifier<List<VisionDetRet>> {
     public List<VisionDetRet> classifyByPath(String imgPath) {
         List<VisionDetRet> ret = new ArrayList<VisionDetRet>();
 
-        if (TextUtils.isEmpty(imgPath) || new File(imgPath).exists() == false) {
+        if (TextUtils.isEmpty(imgPath) || !new File(imgPath).exists()) {
             Log.e(TAG, "classifyByPath. Invalid Input path");
             return ret;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1125 - Literal boolean values should not be used in condition expressions

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1125

Please let me know if you have any questions.

M-Ezzat
