### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/app/src/main/java/com/tzutalin/vision/demo/AutoFitTextureView.java
+++ b/app/src/main/java/com/tzutalin/vision/demo/AutoFitTextureView.java
@@ -12,8 +12,8 @@ import android.view.TextureView;
  */
 public class AutoFitTextureView extends TextureView {
 
-    private int mRatioWidth = 0;
-    private int mRatioHeight = 0;
+    private int mRatioWidth;
+    private int mRatioHeight;
 
     public AutoFitTextureView(Context context) {
         this(context, null);

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/CaffeClassifier.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/CaffeClassifier.java
@@ -34,7 +34,7 @@ import java.util.List;
  * @param <T>
  */
 public abstract class CaffeClassifier<T> {
-    protected static boolean sInitialized = false;
+    protected static boolean sInitialized;
     static {
         try {
             System.loadLibrary("objrek");

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/ObjectDetector.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/ObjectDetector.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class ObjectDetector extends CaffeClassifier <List<VisionDetRet>>{
     private static final String TAG = "ObjectDetector";
-    private ByteBuffer _handler = null;
+    private ByteBuffer _handler;
 
     /**
      * Creates a ObjectDetector, configured with its model path, trained weights, etc.

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/SceneClassifier.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/SceneClassifier.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class SceneClassifier extends CaffeClassifier<List<VisionDetRet>> {
     private static final String TAG = "SceneClassifier";
     private static final int MODEL_DIM = 224;
-    private ByteBuffer _handler = null;
+    private ByteBuffer _handler;
 
     /**
      * Creates a SceneClassifier, configured with its model path, trained weights, etc.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat
