### PR TITLE
squid:S2293 - The diamond operator should be used

### DIFF
--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/CaffeClassifier.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/CaffeClassifier.java
@@ -120,7 +120,7 @@ public abstract class CaffeClassifier<T> {
             try {
                 br = new BufferedReader(new FileReader(file));
                 String line;
-                List<String> lines = new ArrayList<String>();
+                List<String> lines = new ArrayList<>();
                 while ((line = br.readLine()) != null) {
                     String temp = line.substring(line.lastIndexOf("/") + 1);
                     lines.add(temp.split(" ")[0]);

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/ObjectDetector.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/ObjectDetector.java
@@ -87,7 +87,7 @@ public class ObjectDetector extends CaffeClassifier <List<VisionDetRet>>{
      */
     @Override
     public List<VisionDetRet> classifyByPath(String imgPath) {
-        List<VisionDetRet> ret = new ArrayList<VisionDetRet>();
+        List<VisionDetRet> ret = new ArrayList<>();
 
         if (TextUtils.isEmpty(imgPath) || !new File(imgPath).exists()) {
             Log.e(TAG, "classifyByPath. Invalid Input path");
@@ -119,7 +119,7 @@ public class ObjectDetector extends CaffeClassifier <List<VisionDetRet>>{
             throw new IllegalArgumentException(
                     "bitmap size doesn't match initialization");
         }*/
-        List<VisionDetRet> ret = new ArrayList<VisionDetRet>();
+        List<VisionDetRet> ret = new ArrayList<>();
 
         // Check input
         if (bitmap == null) {

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/SceneClassifier.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/SceneClassifier.java
@@ -68,7 +68,7 @@ public class SceneClassifier extends CaffeClassifier<List<VisionDetRet>> {
      */
     @Override
     public List<VisionDetRet> classifyByPath(String imgPath) {
-        List<VisionDetRet> ret = new ArrayList<VisionDetRet>();
+        List<VisionDetRet> ret = new ArrayList<>();
 
         if (TextUtils.isEmpty(imgPath) || !new File(imgPath).exists()) {
             Log.e(TAG, "classifyByPath. Invalid Input path");
@@ -101,7 +101,7 @@ public class SceneClassifier extends CaffeClassifier<List<VisionDetRet>> {
      */
     @Override
     public List<VisionDetRet> classify(Bitmap bitmap) {
-        List<VisionDetRet> ret = new ArrayList<VisionDetRet>();
+        List<VisionDetRet> ret = new ArrayList<>();
 
         // Check input
         if (bitmap == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - The diamond operator ("<>") should be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2293

Please let me know if you have any questions.

M-Ezzat
