### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/Utils.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/Utils.java
@@ -29,7 +29,12 @@ import java.util.TreeMap;
 /**
  * Created by darrenl on 2015/9/10.
  */
-public class Utils {
+public final class Utils {
+
+    private Utils() throws InstantiationException {
+        throw new InstantiationException("This class is not for initialization");
+    }
+
     @NonNull
     public static Map<String, Float> sortPrediction(@NonNull String[] synsets, @NonNull float[] propArray) {
         HashMap<String, Float> map = new HashMap<>();

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/VisionClassifierCreator.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/VisionClassifierCreator.java
@@ -24,7 +24,7 @@ import java.io.File;
 /**
  * Create an instance using default instances for vision recognition and detection
  */
-public class VisionClassifierCreator {
+public final class VisionClassifierCreator {
     private final static String SCENE_MODEL_PATH = "/sdcard/vision_scene/mit/deploy_places205_mem.protxt";
     private final static String SCENE_WIEGHTS_PATH = "/sdcard/vision_scene/mit/googlelet_places205_train_iter_2400000.caffemodel";
     private final static String SCENE_MEAN_FILE = null;
@@ -34,6 +34,10 @@ public class VisionClassifierCreator {
     private final static String DETECT_WIEGHTS_PATH = "/sdcard/fastrcnn/caffenet_fast_rcnn_iter_40000.caffemodel";
     private final static String DETECT_MEAN_FILE = "/sdcard/fastrcnn/imagenet_mean.binaryproto";
     private final static String DETECT_SYNSET_FILE = "/sdcard/fastrcnn/fastrcnn_synset";
+
+    private VisionClassifierCreator() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     /**
      * Create an instance using a default {@link SceneClassifier} instance


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
