### PR TITLE
Multiple quality improvements

### DIFF
--- a/app/src/main/java/com/tzutalin/vision/demo/Camera2BasicFragment.java
+++ b/app/src/main/java/com/tzutalin/vision/demo/Camera2BasicFragment.java
@@ -262,12 +262,12 @@ public class Camera2BasicFragment extends Fragment
     /**
      * A {@link Semaphore} to prevent the app from exiting before closing the camera.
      */
-    private Semaphore mCameraOpenCloseLock = new Semaphore(1);
+    private final Semaphore mCameraOpenCloseLock = new Semaphore(1);
 
     /**
      * A {@link CameraCaptureSession.CaptureCallback} that handles events related to JPEG capture.
      */
-    private CameraCaptureSession.CaptureCallback mCaptureCallback
+    private final CameraCaptureSession.CaptureCallback mCaptureCallback
             = new CameraCaptureSession.CaptureCallback() {
 
         private void process(CaptureResult result) {
@@ -313,6 +313,8 @@ public class Camera2BasicFragment extends Fragment
                     }
                     break;
                 }
+                default:
+                    break;
             }
         }
 
@@ -518,11 +520,6 @@ public class Camera2BasicFragment extends Fragment
      * Opens the camera specified by {@link Camera2BasicFragment#mCameraId}.
      */
     private void openCamera(int width, int height) {
-       /* if (getActivity().checkSelfPermission(Manifest.permission.CAMERA)
-                != PackageManager.PERMISSION_GRANTED) {
-            requestCameraPermission();
-            return;
-        }*/
         setUpCameraOutputs(width, height);
         configureTransform(width, height);
         Activity activity = getActivity();
@@ -762,7 +759,6 @@ public class Camera2BasicFragment extends Fragment
                 public void onCaptureCompleted(@NonNull CameraCaptureSession session,
                                                @NonNull CaptureRequest request,
                                                @NonNull TotalCaptureResult result) {
-                    //showToast("Saved: " + mFile);
                     Log.d(TAG, mFile.toString());
                     unlockFocus();
 
@@ -831,6 +827,8 @@ public class Camera2BasicFragment extends Fragment
                 }
                 break;
             }
+            default:
+                break;
         }
     }
 

--- a/app/src/main/java/com/tzutalin/vision/demo/ObjectDetectActivity.java
+++ b/app/src/main/java/com/tzutalin/vision/demo/ObjectDetectActivity.java
@@ -103,7 +103,6 @@ public class ObjectDetectActivity extends Activity {
                     mObjectDet = VisionClassifierCreator.createObjectDetector(getApplicationContext());
                     // TODO: Get Image's height and width
                     mObjectDet.init(0, 0);
-                    //mObjectDet.setSelectedLabel("person");
                 } catch (IllegalAccessException e) {
                     e.printStackTrace();
                 }

--- a/app/src/main/java/com/tzutalin/vision/demo/SceneRecognitionActivity.java
+++ b/app/src/main/java/com/tzutalin/vision/demo/SceneRecognitionActivity.java
@@ -136,7 +136,7 @@ public class SceneRecognitionActivity extends Activity {
                 Log.d(TAG, "format:" + options.inPreferredConfig);
                 Bitmap bitmapImg = BitmapFactory.decodeFile(filePath, options);
                 startTime = System.currentTimeMillis();
-                rets.addAll(mClassifier.classify(bitmapImg));//mClassifier.classifyByPath(filePath);
+                rets.addAll(mClassifier.classify(bitmapImg));
 
                 endTime = System.currentTimeMillis();
                 final double diffTime = (double) (endTime - startTime) / 1000;

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/ObjectDetector.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/ObjectDetector.java
@@ -115,10 +115,6 @@ public class ObjectDetector extends CaffeClassifier <List<VisionDetRet>>{
      */
     @Override
     public List<VisionDetRet> classify(Bitmap bitmap) {
-        /*if (bitmap.getWidth() != mImgWidth || bitmap.getHeight() != mImgHeight) {
-            throw new IllegalArgumentException(
-                    "bitmap size doesn't match initialization");
-        }*/
         List<VisionDetRet> ret = new ArrayList<>();
 
         // Check input

--- a/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/SceneClassifier.java
+++ b/cnnlibs/src/main/java/com/tzutalin/vision/visionrecognition/SceneClassifier.java
@@ -77,10 +77,10 @@ public class SceneClassifier extends CaffeClassifier<List<VisionDetRet>> {
 
         float[] propArray = jniClassifyImgByPath(imgPath);
         if (propArray != null) {
-            Map<String, Float> sortedmap = Utils.sortPrediction(mSynsets, propArray);
+            Map<String, Float> sortedMap = Utils.sortPrediction(mSynsets, propArray);
             int kSize = 10;
-            for (String key : sortedmap.keySet()) {
-                VisionDetRet det = new VisionDetRet(key, sortedmap.get(key), 0, 0, 0, 0);
+            for (Map.Entry<String, Float> sortedmapEntry : sortedMap.entrySet()) {
+                VisionDetRet det = new VisionDetRet(sortedmapEntry.getKey(), sortedmapEntry.getValue(), 0, 0, 0, 0);
                 ret.add(det);
                 if (kSize == ret.size())
                     break;
@@ -115,8 +115,8 @@ public class SceneClassifier extends CaffeClassifier<List<VisionDetRet>> {
         if (propArray != null) {
             Map<String, Float> sortedmap = Utils.sortPrediction(mSynsets, propArray);
             int kSize = 10;
-            for (String key : sortedmap.keySet()) {
-                VisionDetRet det = new VisionDetRet(key, sortedmap.get(key), 0, 0, 0, 0);
+            for (Map.Entry<String, Float> sortedMapEntry : sortedmap.entrySet()) {
+                VisionDetRet det = new VisionDetRet(sortedMapEntry.getKey(), sortedMapEntry.getValue(), 0, 0, 0, 0);
                 ret.add(det);
                 if (kSize == ret.size())
                     break;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:SwitchLastCaseIsDefaultCheck - "entrySet()" should be iterated when both the key and value are needed
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause
squid:CommentedOutCodeLine - Sections of code should not be "commented out"
pmd:ImmutableField - Immutable Field

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=pmd:ImmutableField

Please let me know if you have any questions.

M-Ezzat
